### PR TITLE
Fix typo in exception message

### DIFF
--- a/src/main/scala/scaldi/Injectable.scala
+++ b/src/main/scala/scaldi/Injectable.scala
@@ -43,7 +43,7 @@ trait Injectable extends Wire {
     injector getBinding ids flatMap (_.get) map (_.asInstanceOf[T]) getOrElse default
 
   private def noBindingFound(ids: List[Identifier]) =
-    throw new InjectException(ids map ("  * " +) mkString ("No biding found with following identifiers:\n", "\n", ""))
+    throw new InjectException(ids map ("  * " +) mkString ("No binding found with following identifiers:\n", "\n", ""))
 
   // in case is identifier goes at first
 


### PR DESCRIPTION
Fixed a typo: "biding" -> "binding"
