### PR TITLE
Makes ambiguous bindings throw exception

### DIFF
--- a/src/main/scala/scaldi/Module.scala
+++ b/src/main/scala/scaldi/Module.scala
@@ -29,7 +29,15 @@ trait Module extends WordBinder
   /**
    * @inheritdoc
    */
-  def getBindingInternal(identifiers: List[Identifier]) = wordBindings find (_ isDefinedFor identifiers)
+  def getBindingInternal(identifiers: List[Identifier]) = {
+    val bindings = getBindingsInternal(identifiers)
+    if (bindings.size > 1)
+      throw new BindingException(
+        s"""Ambiguous match when retrieving binding with following identifiers: ${identifiers.mkString("", ",", "")}.
+            Please supply additional identifiers to disambiguate the binding""")
+
+    bindings.headOption
+  }
 
   /**
    * @inheritdoc

--- a/src/test/scala/scaldi/ModuleSpec.scala
+++ b/src/test/scala/scaldi/ModuleSpec.scala
@@ -1,0 +1,25 @@
+package scaldi
+
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class ModuleSpec extends WordSpec with Matchers {
+  "Module" should {
+    "throw exception when binding is ambiguous" in {
+      import scaldi.Injectable._
+
+      implicit val injector = new Module {
+        binding to 1
+        binding to 42
+
+        binding identifiedBy 'httpPort to "4321"
+        binding identifiedBy 'httpPort to "1234"
+      }
+
+      an [BindingException] should be thrownBy inject [Int]
+      an [BindingException] should be thrownBy inject [String] (identified by 'httpPort)
+    }
+  }
+}
+


### PR DESCRIPTION
In my opinion there should never be the case for ambiguous bindings as it may lead to hard-traceable errors.
