### PR TITLE
New Injector with check for ambiguous bindings

### DIFF
--- a/src/main/scala/scaldi/Injector.scala
+++ b/src/main/scala/scaldi/Injector.scala
@@ -55,6 +55,28 @@ trait MutableInjector extends Injector
   */
 trait ImmutableInjector extends Injector
 
+/**
+ * Stackable trait for ambiguous bindings check
+ */
+trait AmbiguousAwareInjector extends Injector {
+
+  /**
+   * @inheritdoc
+   *
+   * @throws BindingException - if there is more than one binding available for identifier
+   */
+  @throws(classOf[BindingException])
+  abstract override def getBinding(identifiers: List[Identifier]): Option[Binding] = {
+    if (getBindings(identifiers).size > 1) {
+      throw new BindingException(
+        s"""Ambiguous match when retrieving binding with following identifiers: ${identifiers.mkString("", ",", "")}.
+        Please supply additional identifiers to disambiguate the binding""")
+    }
+    super.getBinding(identifiers)
+  }
+}
+
+
 object Injector extends LowPriorityImmutableInjectorComposition {
 
   /**
@@ -322,12 +344,12 @@ trait InjectorWithLifecycle[I <: InjectorWithLifecycle[I]] extends Injector with
   /**
    * @inheritdoc
    */
-  final def getBinding(identifiers: List[Identifier]) = initNonLazy() |> (_ getBindingInternal identifiers map (Binding.apply(this, _)))
+  def getBinding(identifiers: List[Identifier]) = initNonLazy() |> (_ getBindingInternal identifiers map (Binding.apply(this, _)))
 
   /**
    * @inheritdoc
    */
-  final def getBindings(identifiers: List[Identifier]) = initNonLazy() |> (_ getBindingsInternal identifiers map (Binding.apply(this, _)))
+  def getBindings(identifiers: List[Identifier]) = initNonLazy() |> (_ getBindingsInternal identifiers map (Binding.apply(this, _)))
 
   /**
    * Binding lookup logic

--- a/src/test/scala/scaldi/AmbiguousAwareInjectorSpec.scala
+++ b/src/test/scala/scaldi/AmbiguousAwareInjectorSpec.scala
@@ -1,0 +1,53 @@
+package scaldi
+
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class AmbiguousAwareInjectorSpec extends WordSpec with Matchers {
+  "AmbiguousAwareInjector" should {
+    "throw exception when stacked in Module with ambiguous bindings" in {
+      import scaldi.Injectable._
+
+      implicit val injector = new Module with AmbiguousAwareInjector {
+        binding to 1
+        binding to 42
+
+        binding identifiedBy 'httpPort to "4321"
+        binding identifiedBy 'httpPort to "1234"
+      }
+
+      an [BindingException] should be thrownBy inject [Int]
+      an [BindingException] should be thrownBy inject [String] (identified by 'httpPort)
+    }
+
+    "throw exception when stacked in StaticModule with ambiguous bindings" in {
+      import scaldi.Injectable._
+
+      implicit val injector = new StaticModule with AmbiguousAwareInjector {
+        val tcpHost = "tcp-test"
+        val tcpPort = 1234
+        val httpHost = "localhost"
+        val httpPort = 4321
+      }
+
+      an [BindingException] should be thrownBy inject [Int]
+      inject [String] (identified by 'tcpHost) should be("tcp-test")
+    }
+
+    "throw exception when stacked in DynamicModule with ambiguous bindings" in {
+      import scaldi.Injectable._
+
+      implicit val injector = new DynamicModule with AmbiguousAwareInjector {
+        binding to 1
+        binding to 42
+
+        binding identifiedBy 'httpPort to "4321"
+        binding identifiedBy 'httpPort to "1234"
+      }
+
+      an [BindingException] should be thrownBy inject [Int]
+      an [BindingException] should be thrownBy inject [String] (identified by 'httpPort)
+    }
+  }
+}


### PR DESCRIPTION
Related to https://github.com/scaldi/scaldi/issues/69 
I would propose to allow the user specify the behaviour: should the error be thrown in ambiguous case or not. The proposed trait can be stacked into Modules, where that make sence, and at the same time do not affect the existing implementations. Thanks @Mironor for the initial effort (https://github.com/scaldi/scaldi/pull/70)

Qustions: 
 - that would not throw an exception for RawInjector
 - how to override the binding for AmbiguousAwareInjector in tests?
 - InjectorWithLifecycle has no final methods. Why are they final?  

Looking forward for @OlegIlyenko and @Mironor feedback and discussion. 